### PR TITLE
Add Content Pig

### DIFF
--- a/site/content/projects/content-pig.md
+++ b/site/content/projects/content-pig.md
@@ -1,0 +1,21 @@
+---
+title: Content Pig
+repo: content-pig
+homepage: https://www.content-pig.com/
+opensource: "No"
+typeofcms: "API Driven"
+supportedgenerators:
+  - All
+description: An API-based CMS for all of your apps and devices.
+---
+## Content Pig
+Create content using our powerful editor interface and access it through our RESTful API. Supports collaborative editing, versioning management and easy integration with any blog, app or device.
+
+## Empower your editors with Git
+Through the power of Git, we're able to offer a variety of features out of the box. Think user collaboration, visual diff-ing, versioning and more. With Git, you start with a solid foundation for building an awesome content editing experience.
+
+## Test and Tweak your Content
+Refine your content marketing strategy through our unique testing platform. Get insight into the effectiveness of your content through automated A/B tests.
+
+## You Own Everything
+Any content you create is yours. Get all your content back in a simple format at the touch of a button. Since everything is stored in a Git repository, you can push, pull or clone your content wherever you need it.


### PR DESCRIPTION
Adding Content pig (https://www.content-pig.com) to the list of headless CMS's.