### PR TITLE
Change Appernetic to closed source

### DIFF
--- a/site/content/projects/appernetic.md
+++ b/site/content/projects/appernetic.md
@@ -2,7 +2,7 @@
 title: Appernetic
 repo: appernetic
 homepage: https://appernetic.io
-opensource: "Yes"
+opensource: "No"
 typeofcms: "Git-based"
 supportedgenerators:
   - Hugo


### PR DESCRIPTION
Although Appernetic as organization have some open source presence, Appernetic.io as a product/CMS is not open sourced.