### PR TITLE
Change Sanity to closed-source

### DIFF
--- a/site/content/projects/sanity.md
+++ b/site/content/projects/sanity.md
@@ -2,7 +2,7 @@
 title: Sanity
 repo: sanity-io/sanity
 homepage: https://www.sanity.io
-opensource: "Yes"
+opensource: "No"
 typeofcms: "API Driven"
 supportedgenerators:
   - All


### PR DESCRIPTION
While the front-end construction kit is open source, the API itself (which I would consider the core of the CMS) is a proprietary service.