### PR TITLE
Use "Jamstack" as per jamstack.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Missing a headless CMS here? Just fork the repo and add yours as a `<name>.md` i
 Make sure to follow the following rules:
 
 *   **Truly headless:** This means your CMS must interact with content and data, and cannot be responsible for building the site.
-*   **JAMstack:** Your CMS has to work with the JAMstack methodology: JavaScript, API's and Markup.
+*   **Jamstack:** Your CMS has to work with the Jamstack methodology: JavaScript, API's and Markup.
 *   **Stick to the format:** Fill out all the same fields as the other CMS's in `content/projects`.
 *   **Short description:** Keep all the details for the body text, keep the description for the overview page short and sweet.
 

--- a/content/pages/about.md
+++ b/content/pages/about.md
@@ -4,9 +4,9 @@ title: About HeadlessCMS
 
 # About HeadlessCMS
 
-HeadlessCMS.org is an overview of the top Content Management tools for JAMstack sites.
+HeadlessCMS.org is an overview of the top Content Management tools for Jamstack sites.
 
-'Headless CMS' is also commonly known as 'JAMstack CMS' or 'Decoupled CMS'.
+'Headless CMS' is also commonly known as 'Jamstack CMS' or 'Decoupled CMS'.
 
 ## What is a Headless CMS
 
@@ -23,11 +23,11 @@ You could also say that any content management tool that can manage content on s
 
 ## Why is Headless better than legacy systems
 
-The advantages of this approach is huge, and it works with [JAMstack](https://www.jamstack.org/) sites that are many times faster safer and cheaper to scale than traditional sites.
+The advantages of this approach is huge, and it works with [Jamstack](https://www.Jamstack.org/) sites that are many times faster safer and cheaper to scale than traditional sites.
 
 ## Who makes this
 
-Headlesscms.org is run by [Netlify](https://www.netlify.com), an automation and deployment service for Headless CMS and JAMstack sites  in general, as a way to promote the JAMstack approach to building websites.
+Headlesscms.org is run by [Netlify](https://www.netlify.com), an automation and deployment service for Headless CMS and Jamstack sites  in general, as a way to promote the Jamstack approach to building websites.
 
 ## How is it made
 

--- a/content/pages/contribute.md
+++ b/content/pages/contribute.md
@@ -12,4 +12,4 @@ We'll only accept pull requests adding new CMS' if they follow these rules:
 - **Stick to the format:** Fill out all the same fields as the other CMS's in source/projects.
 - **Short description:** Keep all the details for the body text, keep the description for the overview page short and sweet.
 
-There are lots of traditional CMS listing out there, but for this one we're focusing on [JAMStack](https://www.jamstack.org) solutions that will work for sites built with static site generators or similar modern buildtools.
+There are lots of traditional CMS listing out there, but for this one we're focusing on [Jamstack](https://www.jamstack.org) solutions that will work for sites built with static site generators or similar modern buildtools.

--- a/content/projects/flotiq.md
+++ b/content/projects/flotiq.md
@@ -12,14 +12,14 @@ images:
 ---
 ## Flotiq
 
-Flotiq is an effortless headless Content Management System. 
+Flotiq is an effortless headless Content Management System.
 Flotiq's goal is to provide developers with an easy to use API and powerful integrations and SDKs that allow them to build complex systems.
 
 ## Where to start?
 
 Head over to [Flotiq Docs](https://flotiq.com/docs/) or start exploring immediately with a [free account](https://editor.flotiq.com/register.html).
 
-We published several deep-dive docs describing how to get started building JAMstack-based apps with Flotiq, try [building a blog in 3 minutes](https://flotiq.com/docs/Deep-Dives/Building-a-blog-in-3-minutes/).
+We published several deep-dive docs describing how to get started building Jamstack-based apps with Flotiq, try [building a blog in 3 minutes](https://flotiq.com/docs/Deep-Dives/Building-a-blog-in-3-minutes/).
 
 ## Key features
 

--- a/content/projects/netlify-cms.md
+++ b/content/projects/netlify-cms.md
@@ -27,7 +27,7 @@ There is a starter template (created by clicking below) that uses Hugo with Netl
 <div class="promo">
   <div class="deploy-to-netlify">
     <h3>Get started with 1 click</h3>
-    <p>Introducing the "Deploy to Netlify" button on select JAMstack CMSs to help you deploy new sites from generator-specific templates with a single click. Get a site up with a JAMstack CMS in minutes with a custom domain, HTTPS, and continuous delivery completely free of charge.<br><br>
+    <p>Introducing the "Deploy to Netlify" button on select Jamstack CMSs to help you deploy new sites from generator-specific templates with a single click. Get a site up with a Jamstack CMS in minutes with a custom domain, HTTPS, and continuous delivery completely free of charge.<br><br>
     Want your own Deploy to Netlify button? <a href="https://www.netlify.com/docs/deploy_button/">Learn more here</a></p>
       <em>Click below to give it a try with Netlify CMS's Hugo template.</em>
       <a class="deploy-btn-interior inline" href="https://app.netlify.com/start/deploy?repository=https://github.com/netlify-templates/one-click-hugo-cms" alt="Deploy to Netlify" title="Deploy to Netlify">

--- a/content/projects/sanity.md
+++ b/content/projects/sanity.md
@@ -22,7 +22,7 @@ Get started from the command line:
 npm i -g @sanity/cli && sanity init
 ```
 
-Or go to [sanity.io/create](https://www.sanity.io/create) to get started with a headless JAMstack website deployed on [Netlify](https://netlify.com) in minutes: [Gatsby Blog](https://www.sanity.io/create?template=sanity-io/sanity-template-gatsby-blog), [Gatsby Portfolio](https://www.sanity.io/create?template=sanity-io/sanity-template-gatsby-portfolio), [Next.js Landing Pages](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-nextjs-landing-pages), [Gridsome Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-gridsome-blog), [Nuxt.js Events page](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-nuxt-events), [Sapper Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-sapper-blog), [Eleventy Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-eleventy-blog).
+Or go to [sanity.io/create](https://www.sanity.io/create) to get started with a headless Jamstack website deployed on [Netlify](https://netlify.com) in minutes: [Gatsby Blog](https://www.sanity.io/create?template=sanity-io/sanity-template-gatsby-blog), [Gatsby Portfolio](https://www.sanity.io/create?template=sanity-io/sanity-template-gatsby-portfolio), [Next.js Landing Pages](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-nextjs-landing-pages), [Gridsome Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-gridsome-blog), [Nuxt.js Events page](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-nuxt-events), [Sapper Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-sapper-blog), [Eleventy Blog](https://www.sanity.io/create?template=sanity-io%2Fsanity-template-eleventy-blog).
 
 - Watch the [getting started video on YouTube](https://www.youtube.com/watch?v=2ceM_tSus_M&lc=z224vtt5nqq1cbcf2acdp43aylzlb5jhft1kmuafltxw03c010c).
 - [Read the introduction](https://www.sanity.io/docs/a-short-introduction-to-sanity-io) in the documentation
@@ -48,7 +48,7 @@ Or go to [sanity.io/create](https://www.sanity.io/create) to get started with a 
 - [Secure, scalable and GDPR compliant](https://www.sanity.io/security)
 - [Zero config Graph Oriented Query Language (GROQ)](https://www.sanity.io/docs/how-queries-work), and [GraphQL API](https://www.sanity.io/docs/graphql)
 - [Helpful and friendly developer community](https://slack.sanity.io)
-- Build the CMS solution you need:[React CMS](https://www.sanity.io/react-cms), [eCommerce CMS](https://www.sanity.io/ecommerce-cms), [Gatsby CMS](https://www.sanity.io/gatsby-cms), [JAMstack CMS](https://www.sanity.io/jamstack-cms), [Mobile CMS](https://www.sanity.io/mobile-cms)
+- Build the CMS solution you need:[React CMS](https://www.sanity.io/react-cms), [eCommerce CMS](https://www.sanity.io/ecommerce-cms), [Gatsby CMS](https://www.sanity.io/gatsby-cms), [Jamstack CMS](https://www.sanity.io/Jamstack-cms), [Mobile CMS](https://www.sanity.io/mobile-cms)
 
 ### [Structured Content](https://www.sanity.io/structured-content)
 

--- a/content/projects/tinacms.md
+++ b/content/projects/tinacms.md
@@ -19,7 +19,7 @@ Tina is a **lightweight but powerful toolkit** for creating a content editing in
 
 ![tina-gif](https://res.cloudinary.com/forestry-demo/video/upload/du_16,w_700,e_loop/v1571159974/tina-hero-demo.gif)
 
-Tina is optimized for next-gen JAMstack tools. It is written in JavaScript and easily adapted to multiple different frameworks.
+Tina is optimized for next-gen Jamstack tools. It is written in JavaScript and easily adapted to multiple different frameworks.
 
 Tina currently supports React-based frameworks, including:
 
@@ -29,7 +29,7 @@ Tina currently supports React-based frameworks, including:
 
 ## Get Started
 
-To use Tina, you should have a good working knowledge of your JavaScript framework & JAMstack tools of choice.
+To use Tina, you should have a good working knowledge of your JavaScript framework & Jamstack tools of choice.
 
 To get a better idea of what Tina is all about, take a look at [how Tina works](https://tinacms.org/docs/getting-started/how-tina-works 'How Tina Works').
 

--- a/src/App/Footer.js
+++ b/src/App/Footer.js
@@ -4,7 +4,7 @@ const Footer = () => (
   <div>
     <div className="footer">
       <div className="footer-container">
-        <h3>HeadlessCMS is hosted and maintained by <a href="https://www.netlify.com">Netlify</a>, the perfect way to deploy your JAMstack sites and apps.</h3>
+        <h3>HeadlessCMS is hosted and maintained by <a href="https://www.netlify.com">Netlify</a>, the perfect way to deploy your <a href="https://www.netlify.com/jamstack">Jamstack sites and apps</a>.</h3>
       </div>
       <div className="postscript">
         © Netlify {new Date().getFullYear()}

--- a/src/App/Header.js
+++ b/src/App/Header.js
@@ -47,7 +47,7 @@ const ShareButton = styled(({
 const AnnouncementBar = ({ className }) => (
   <div className={className}>
     <p>
-      Share your JAMstack technology decisions and experiences. <a href="https://www.surveymonkey.com/r/DH9KZZT" target="_blank" rel="noopener noreferrer">Take&nbsp;the&nbsp;survey&nbsp;by&nbsp;April&nbsp;19</a>
+      Share your Jamstack technology decisions and experiences. <a href="https://www.surveymonkey.com/r/DH9KZZT" target="_blank" rel="noopener noreferrer">Take&nbsp;the&nbsp;survey&nbsp;by&nbsp;April&nbsp;19</a>
     </p>
   </div>
 )
@@ -80,7 +80,7 @@ const Header = () => (
             {`${
               title
                 ? `${title} | headlessCMS`
-                : 'headlessCMS | Top Content Management Systems for JAMstack sites'
+                : 'headlessCMS | Top Content Management Systems for Jamstack sites'
             }`}
           </title>
         </Head>
@@ -91,7 +91,7 @@ const Header = () => (
               <img alt="headlessCMS" src={logo} />
             </Link>
           </h1>
-          <h2>A List of Content Management Systems for JAMstack Sites</h2>
+          <h2>A List of Content Management Systems for Jamstack Sites</h2>
 
           <ShareButtonWrapper>
             <ShareButton
@@ -131,7 +131,7 @@ const Header = () => (
                     rel="noopener noreferrer"
                     target="_blank"
                   >
-                    What is JAMstack?
+                    What is Jamstack?
                   </a>
                 </li>
                 <li>

--- a/static.config.js
+++ b/static.config.js
@@ -138,7 +138,7 @@ export default {
   getRoutes: async () => {
     const projects = await getProjects()
     const pages = await getPages()
-    const defaultShareText = 'Check out headlessCMS, a leaderboard of content management systems for JAMstack sites.'
+    const defaultShareText = 'Check out headlessCMS, a leaderboard of content management systems for Jamstack sites.'
     return [
       {
         path: '/',
@@ -156,7 +156,7 @@ export default {
           getData: () => ({
             ...project,
             shareUrl: `${SITE_URL}/projects/${project.slug}`,
-            shareText: `Check out ${project.title}, a headless CMS for JAMstack sites on the headlessCMS.org leaderboard.`,
+            shareText: `Check out ${project.title}, a headless CMS for Jamstack sites on the headlessCMS.org leaderboard.`,
           }),
         })),
       },
@@ -195,13 +195,13 @@ export default {
 
             <meta content="IE=edge,chrome=1" httpEquiv="X-UA-Compatible" />
 
-            <meta name="twitter:card" value="headlessCMS is a leaderboard of the top Content Management Systems (CMS) for JAMstack sites. Promoting a static approach to websites." />
+            <meta name="twitter:card" value="headlessCMS is a leaderboard of the top Content Management Systems (CMS) for Jamstack sites. Promoting a static approach to websites." />
 
             <meta property="og:title" content="headlessCMS" />
             <meta property="og:type" content="website" />
             <meta property="og:url" content="https://headlesscms.org/" />
             <meta property="og:image" content="https://headlesscms.org/images/headlesscms.png" />
-            <meta property="og:description" content="headlessCMS is a leaderboard of the top Content Management Systems for JAMstack sites. Promoting a static approach to building websites." />
+            <meta property="og:description" content="headlessCMS is a leaderboard of the top Content Management Systems for Jamstack sites. Promoting a static approach to building websites." />
 
             <link href="//fonts.googleapis.com/css?family=Roboto+Slab:700" rel="stylesheet" type="text/css" />
             <link href="//fonts.googleapis.com/css?family=Roboto:100,400,600,700" rel="stylesheet" type="text/css" />


### PR DESCRIPTION
Moving towards more consistent treatment of the word "Jamstack".
This was [discussed in an issue](https://github.com/jamstack/jamstack.org/issues/279) in the jamstack.org site repo, and a decision reached.

These changes bring headlesscms.org into line with that.