### PR TITLE
Add FrontAid CMS

### DIFF
--- a/content/projects/frontaid.md
+++ b/content/projects/frontaid.md
@@ -1,0 +1,29 @@
+---
+title: FrontAid CMS
+homepage: https://frontaid.io/
+twitter: FrontAidCMS
+opensource: "No"
+typeofcms: "Git-based"
+supportedgenerators:
+  - All
+description: FrontAid is a free CMS for JSON files in Git.
+---
+## What is FrontAid CMS?
+FrontAid is a web-based CMS for JSON files that are stored in your own Git repository.
+After the initial setup, a non-developer can manage the content easily.
+And any updates are commited directly to your Git repository.
+
+**FrontAid CMS is completely free**. Try it on [FrontAid.io](https://frontaid.io/).
+
+
+## Features
+
+* **Data Model**: You can define a strict data model in JSON itself. FrontAid CMS only allows content updates that adhere to that model.
+
+* **JSON Objects/Lists**: FrontAid CMS supports any JSON data structure that you might need. Your content can use JSON objects, arrays, or any kind of nested objects/lists.
+
+* **Content Types**: Aside from objects and arrays, FrontAid CMS also supports different types of fields. For example single line input, multi line input, or rich text fields.
+
+* **Localization**: FrontAid CMS can be used with any language or locale that you might need. And you can use it to manage content in just one or multiple languages. You can even manage multiple languages side by side.
+
+* **Powered by Git**: As FrontAid CMS is Git-based, you can use its super powers. Every content change is versioned, you can build arbitrary build steps using Git hooks, or use it together with a CI/CD tool.


### PR DESCRIPTION
Adding FrontAid https://frontaid.io/ as Git-based CMS.