### PR TITLE
Add redirects to jamstack.org

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,6 +1,6 @@
-/ https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/about https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
-/contribute https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
-/contact https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/projects/* https://next-design-iteration--jamstack-site.netlify.app/headless-cms/:splat 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/:splat 301!
+/ https://www.jamstack.org/ 301!
+/contact https://www.jamstack.org/ 301!
+/about https://www.jamstack.org/headless-cms/ 301!
+/contribute https://www.jamstack.org/headless-cms/ 301!
+/projects/* https://www.jamstack.org/headless-cms/:splat 301!
+/* https://www.jamstack.org/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,5 +1,5 @@
 / https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
-/contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
+/about https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
+/contribute https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
 /contact https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!
+/* https://next-design-iteration--jamstack-site.netlify.app/headless-cms/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -1,0 +1,5 @@
+/ https://next-design-iteration--jamstack-site.netlify.app/ 301!
+/about https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
+/contribute https://next-design-iteration--jamstack-site.netlify.app/generators/ 301!
+/contact https://next-design-iteration--jamstack-site.netlify.app/ 301!
+/* https://next-design-iteration--jamstack-site.netlify.app/generators/:splat 301!

--- a/public/_redirects
+++ b/public/_redirects
@@ -2,4 +2,5 @@
 /about https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
 /contribute https://next-design-iteration--jamstack-site.netlify.app/headless-cms/ 301!
 /contact https://next-design-iteration--jamstack-site.netlify.app/ 301!
-/* https://next-design-iteration--jamstack-site.netlify.app/headless-cms/:splat 301!
+/projects/* https://next-design-iteration--jamstack-site.netlify.app/headless-cms/:splat 301!
+/* https://next-design-iteration--jamstack-site.netlify.app/:splat 301!


### PR DESCRIPTION
⚠️ I currently redirects to the deploy preview just to make sure that it works, will edit once it's ready ⚠️

Following [Netlify's Rule processing order](https://docs.netlify.com/routing/redirects/#rule-processing-order) - If you try to access else than:
-  `/`
- `/about`
- `/contribute`
- `/contact`

it will assume that it's a generators and redirect to `/generators/*`

### Test plan

Here's some link to test and make sure the redirect work

https://deploy-preview-369--headlesscms.netlify.app/
https://deploy-preview-369--headlesscms.netlify.app/about
https://deploy-preview-369--headlesscms.netlify.app/contribute
https://deploy-preview-369--headlesscms.netlify.app/contact
https://deploy-preview-369--headlesscms.netlify.app/projects/strapi/
https://deploy-preview-369--headlesscms.netlify.app/projects/ghost/